### PR TITLE
Add MCP server with OAuth 2.1 for Claude Connector

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "@prisma/client": "^6.1.0",
         "@types/multer": "^2.0.0",
         "bcrypt": "^5.1.1",
@@ -804,6 +805,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -908,6 +921,336 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@noble/hashes": {
@@ -2041,6 +2384,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2661,7 +3043,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3228,6 +3609,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3351,7 +3753,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3374,6 +3775,22 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3831,6 +4248,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3987,6 +4413,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4003,7 +4435,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4086,6 +4517,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -4118,6 +4558,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4839,7 +5285,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4883,6 +5328,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -5096,6 +5550,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5175,6 +5638,32 @@
         "@rollup/rollup-win32-x64-gnu": "4.55.1",
         "@rollup/rollup-win32-x64-msvc": "4.55.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -5294,7 +5783,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5307,7 +5795,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6102,7 +6589,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6266,6 +6752,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@prisma/client": "^6.1.0",
     "@types/multer": "^2.0.0",
     "bcrypt": "^5.1.1",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -475,3 +475,63 @@ model ImportJob {
   @@index([createdAt])
   @@map("import_jobs")
 }
+
+// ============================================
+// OAuth 2.1
+// ============================================
+
+model OAuthClient {
+  id           String   @id @default(cuid())
+  clientId     String   @unique @map("client_id")
+  clientSecret String?  @map("client_secret")
+  clientName   String   @map("client_name")
+  redirectUris String[] @map("redirect_uris")
+  grantTypes   String[] @map("grant_types")
+  scope        String?
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  authorizationCodes OAuthAuthorizationCode[]
+  refreshTokens      OAuthRefreshToken[]
+
+  @@index([clientId])
+  @@map("oauth_clients")
+}
+
+model OAuthAuthorizationCode {
+  id                  String    @id @default(cuid())
+  code                String    @unique
+  clientId            String    @map("client_id")
+  userId              String    @map("user_id")
+  tenantId            String    @map("tenant_id")
+  redirectUri         String    @map("redirect_uri")
+  codeChallenge       String    @map("code_challenge")
+  codeChallengeMethod String    @map("code_challenge_method")
+  scope               String?
+  state               String?
+  expiresAt           DateTime  @map("expires_at")
+  usedAt              DateTime? @map("used_at")
+  createdAt           DateTime  @default(now()) @map("created_at")
+
+  client OAuthClient @relation(fields: [clientId], references: [clientId], onDelete: Cascade)
+
+  @@index([code])
+  @@index([clientId])
+  @@map("oauth_authorization_codes")
+}
+
+model OAuthRefreshToken {
+  id        String   @id @default(cuid())
+  tokenHash String   @unique @map("token_hash")
+  clientId  String   @map("client_id")
+  userId    String   @map("user_id")
+  tenantId  String   @map("tenant_id")
+  scope     String?
+  expiresAt DateTime @map("expires_at")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  client OAuthClient @relation(fields: [clientId], references: [clientId], onDelete: Cascade)
+
+  @@index([tokenHash])
+  @@index([clientId])
+  @@map("oauth_refresh_tokens")
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,8 @@ import routes from './routes';
 import { errorHandler, notFound } from './middleware/errorHandler';
 import { logger } from './utils/logger';
 import prisma from './config/database';
+import { mountOAuth } from './oauth';
+import { mountMcp } from './mcp';
 
 dotenv.config();
 
@@ -104,6 +106,9 @@ app.get('/health/startup', (_req, res) => {
 });
 
 app.use('/api', routes);
+
+mountOAuth(app);
+mountMcp(app);
 
 app.use(notFound);
 app.use(errorHandler);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,11 +1,18 @@
+import { execSync } from 'child_process';
 import app from './app';
 import { logger } from './utils/logger';
 import prisma from './config/database';
+import { closeAllSessions } from './mcp';
 
 const PORT = process.env.PORT || 3000;
 
 async function startServer() {
   try {
+    // Apply schema changes to database (idempotent)
+    logger.info('Running prisma db push...');
+    execSync('npx prisma db push --skip-generate', { stdio: 'inherit' });
+    logger.info('Database schema up to date');
+
     // Ensure database is connected before starting server
     await prisma.$connect();
     logger.info('Database connected successfully');
@@ -19,6 +26,7 @@ async function startServer() {
     const gracefulShutdown = async (signal: string) => {
       logger.info(`${signal} received. Shutting down gracefully...`);
       server.close(async () => {
+        await closeAllSessions();
         await prisma.$disconnect();
         logger.info('Server closed');
         process.exit(0);

--- a/backend/src/mcp/index.ts
+++ b/backend/src/mcp/index.ts
@@ -1,0 +1,11 @@
+import { Express } from 'express';
+import { createMcpRouter } from './transport';
+
+export { closeAllSessions } from './transport';
+
+/**
+ * Mount MCP endpoint on Express app
+ */
+export function mountMcp(app: Express): void {
+  app.use('/mcp', createMcpRouter());
+}

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -1,0 +1,75 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { JWTPayload } from '../utils/auth';
+import { AppError } from '../middleware/errorHandler';
+import { logger } from '../utils/logger';
+import { registerOrganizationTools } from './tools/organizations';
+import { registerContactTools } from './tools/contacts';
+import { registerDealTools } from './tools/deals';
+import { registerActivityTools } from './tools/activities';
+import { registerNoteTools } from './tools/notes';
+import { registerReportTools } from './tools/reports';
+
+/**
+ * Wrapper that handles errors and formats MCP responses
+ */
+export function wrapToolHandler(handler: (params: any) => Promise<any>) {
+  return async (params: any) => {
+    try {
+      const result = await handler(params);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error('MCP tool error:', error);
+
+      if (error instanceof AppError) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: ${error.message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  };
+}
+
+/**
+ * Creates an MCP server instance with all tools registered for the authenticated user
+ */
+export function createMcpServer(auth: JWTPayload): McpServer {
+  const server = new McpServer({
+    name: 'SpecterCRM',
+    version: '1.0.0',
+  });
+
+  // Register all tool categories
+  registerOrganizationTools(server, auth, wrapToolHandler);
+  registerContactTools(server, auth, wrapToolHandler);
+  registerDealTools(server, auth, wrapToolHandler);
+  registerActivityTools(server, auth, wrapToolHandler);
+  registerNoteTools(server, auth, wrapToolHandler);
+  registerReportTools(server, auth, wrapToolHandler);
+
+  logger.info(`MCP server created for user ${auth.email} (tenant: ${auth.tenantId})`);
+
+  return server;
+}

--- a/backend/src/mcp/tools/activities.ts
+++ b/backend/src/mcp/tools/activities.ts
@@ -1,0 +1,112 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { JWTPayload } from '../../utils/auth';
+import { ActivityService } from '../../services/activity.service';
+
+export function registerActivityTools(server: McpServer, auth: JWTPayload, wrapToolHandler: any) {
+  server.tool(
+    'list_activities',
+    'List all activities with optional filtering and pagination',
+    {
+      type: z.string().optional().describe('Filter by activity type (e.g., Workshop, POC Demo, Architecture Review)'),
+      ownerUserId: z.string().optional().describe('Filter by owner user ID'),
+      isCompleted: z.boolean().optional().describe('Filter by completion status'),
+      startDate: z.string().optional().describe('Filter by start date (ISO format)'),
+      endDate: z.string().optional().describe('Filter by end date (ISO format)'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+      limit: z.number().optional().describe('Results per page (default: 20)'),
+      sortBy: z.string().optional().describe('Sort field (default: dueAt)'),
+      sortOrder: z.enum(['asc', 'desc']).optional().describe('Sort order (default: asc)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return ActivityService.findAll({
+        tenantId: auth.tenantId,
+        type: params.type,
+        ownerUserId: params.ownerUserId,
+        isCompleted: params.isCompleted,
+        startDate: params.startDate,
+        endDate: params.endDate,
+        page: params.page,
+        limit: params.limit,
+        sortBy: params.sortBy,
+        sortOrder: params.sortOrder,
+      });
+    })
+  );
+
+  server.tool(
+    'get_activity',
+    'Get detailed information about a specific activity by ID',
+    {
+      id: z.string().describe('Activity ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return ActivityService.findById(params.id, auth.tenantId);
+    })
+  );
+
+  server.tool(
+    'create_activity',
+    'Create a new activity (technical touchpoint, workshop, POC demo, etc.)',
+    {
+      type: z.string().describe('Activity type (required)'),
+      subject: z.string().describe('Activity subject/title (required)'),
+      description: z.string().optional().describe('Activity description'),
+      dueAt: z.string().optional().describe('Due date/time (ISO format)'),
+      relatedOrganizationId: z.string().optional().describe('Related organization ID'),
+      organizationIds: z.array(z.string()).optional().describe('Additional organization IDs'),
+      relatedDealId: z.string().optional().describe('Related deal ID'),
+      contactIds: z.array(z.string()).optional().describe('Contact IDs'),
+      ownerUserId: z.string().optional().describe('Owner user ID (defaults to current user)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return ActivityService.create(
+        {
+          type: params.type,
+          subject: params.subject,
+          description: params.description,
+          dueAt: params.dueAt,
+          relatedOrganizationId: params.relatedOrganizationId,
+          organizationIds: params.organizationIds,
+          relatedDealId: params.relatedDealId,
+          contactIds: params.contactIds,
+          ownerUserId: params.ownerUserId,
+        },
+        auth.tenantId,
+        auth.userId
+      );
+    })
+  );
+
+  server.tool(
+    'update_activity',
+    'Update an existing activity',
+    {
+      id: z.string().describe('Activity ID'),
+      type: z.string().optional().describe('Activity type'),
+      subject: z.string().optional().describe('Activity subject/title'),
+      description: z.string().optional().describe('Activity description'),
+      dueAt: z.string().optional().describe('Due date/time (ISO format)'),
+      relatedOrganizationId: z.string().optional().describe('Related organization ID'),
+      organizationIds: z.array(z.string()).optional().describe('Additional organization IDs'),
+      relatedDealId: z.string().optional().describe('Related deal ID'),
+      contactIds: z.array(z.string()).optional().describe('Contact IDs'),
+      ownerUserId: z.string().optional().describe('Owner user ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      const { id, ...data } = params;
+      return ActivityService.update(id, data, auth.tenantId, auth.userId);
+    })
+  );
+
+  server.tool(
+    'toggle_activity_complete',
+    'Toggle the completion status of an activity',
+    {
+      id: z.string().describe('Activity ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return ActivityService.toggleComplete(params.id, auth.tenantId, auth.userId);
+    })
+  );
+}

--- a/backend/src/mcp/tools/contacts.ts
+++ b/backend/src/mcp/tools/contacts.ts
@@ -1,0 +1,140 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { JWTPayload } from '../../utils/auth';
+import { ContactService } from '../../services/contact.service';
+
+export function registerContactTools(server: McpServer, auth: JWTPayload, wrapToolHandler: any) {
+  server.tool(
+    'list_contacts',
+    'List all contacts with optional filtering, search, and pagination',
+    {
+      search: z.string().optional().describe('Search by name or email'),
+      ownerUserId: z.string().optional().describe('Filter by owner user ID'),
+      organizationId: z.string().optional().describe('Filter by organization ID'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+      limit: z.number().optional().describe('Results per page (default: 20)'),
+      sortBy: z.string().optional().describe('Sort field (default: createdAt)'),
+      sortOrder: z.enum(['asc', 'desc']).optional().describe('Sort order (default: desc)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return ContactService.findAll({
+        tenantId: auth.tenantId,
+        search: params.search,
+        ownerUserId: params.ownerUserId,
+        organizationId: params.organizationId,
+        page: params.page,
+        limit: params.limit,
+        sortBy: params.sortBy,
+        sortOrder: params.sortOrder,
+      });
+    })
+  );
+
+  server.tool(
+    'get_contact',
+    'Get detailed information about a specific contact by ID',
+    {
+      id: z.string().describe('Contact ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return ContactService.findById(params.id, auth.tenantId);
+    })
+  );
+
+  server.tool(
+    'create_contact',
+    'Create a new contact',
+    {
+      firstName: z.string().describe('First name (required)'),
+      lastName: z.string().describe('Last name (required)'),
+      jobTitle: z.string().optional().describe('Job title'),
+      contactRole: z.string().optional().describe('Contact role (e.g., CTO, Head of Streaming)'),
+      primaryOrganizationId: z.string().describe('Primary organization ID (required)'),
+      ownerUserId: z.string().optional().describe('Owner user ID (defaults to current user)'),
+      emails: z.array(z.object({
+        email: z.string().describe('Email address'),
+        isPrimary: z.boolean().describe('Is this the primary email'),
+      })).describe('Email addresses (at least one required)'),
+      phones: z.array(z.object({
+        phone: z.string().describe('Phone number'),
+        type: z.string().optional().describe('Phone type (e.g., Mobile, Work)'),
+        isPrimary: z.boolean().describe('Is this the primary phone'),
+      })).optional().describe('Phone numbers'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return ContactService.create(
+        {
+          firstName: params.firstName,
+          lastName: params.lastName,
+          jobTitle: params.jobTitle,
+          contactRole: params.contactRole,
+          primaryOrganizationId: params.primaryOrganizationId,
+          ownerUserId: params.ownerUserId,
+          emails: params.emails,
+          phones: params.phones,
+        },
+        auth.tenantId,
+        auth.userId
+      );
+    })
+  );
+
+  server.tool(
+    'update_contact',
+    'Update an existing contact',
+    {
+      id: z.string().describe('Contact ID'),
+      firstName: z.string().optional().describe('First name'),
+      lastName: z.string().optional().describe('Last name'),
+      jobTitle: z.string().optional().describe('Job title'),
+      contactRole: z.string().optional().describe('Contact role'),
+      primaryOrganizationId: z.string().optional().describe('Primary organization ID'),
+      ownerUserId: z.string().optional().describe('Owner user ID'),
+      emails: z.array(z.object({
+        email: z.string().describe('Email address'),
+        isPrimary: z.boolean().describe('Is this the primary email'),
+      })).optional().describe('Email addresses'),
+      phones: z.array(z.object({
+        phone: z.string().describe('Phone number'),
+        type: z.string().optional().describe('Phone type'),
+        isPrimary: z.boolean().describe('Is this the primary phone'),
+      })).optional().describe('Phone numbers'),
+    },
+    wrapToolHandler(async (params: any) => {
+      const { id, ...data } = params;
+      return ContactService.update(id, data, auth.tenantId, auth.userId);
+    })
+  );
+
+  server.tool(
+    'delete_contact',
+    'Delete a contact',
+    {
+      id: z.string().describe('Contact ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      await ContactService.delete(params.id, auth.tenantId, auth.userId);
+      return { success: true, message: 'Contact deleted successfully' };
+    })
+  );
+
+  server.tool(
+    'get_contact_activities',
+    'Get all activities associated with a contact',
+    {
+      contactId: z.string().describe('Contact ID'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+      limit: z.number().optional().describe('Results per page (default: 20)'),
+      isCompleted: z.boolean().optional().describe('Filter by completion status'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return ContactService.getActivities(
+        params.contactId,
+        auth.tenantId,
+        params.page,
+        params.limit,
+        params.isCompleted
+      );
+    })
+  );
+}

--- a/backend/src/mcp/tools/deals.ts
+++ b/backend/src/mcp/tools/deals.ts
@@ -1,0 +1,147 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { JWTPayload } from '../../utils/auth';
+import { DealService } from '../../services/deal.service';
+import { DealStage } from '@prisma/client';
+
+export function registerDealTools(server: McpServer, auth: JWTPayload, wrapToolHandler: any) {
+  server.tool(
+    'list_deals',
+    'List all deals with optional filtering, search, and pagination',
+    {
+      search: z.string().optional().describe('Search by title or organization name'),
+      stage: z.enum(['LEAD', 'PROSPECT', 'QUOTE', 'WON', 'LOST']).optional().describe('Filter by deal stage'),
+      ownerUserId: z.string().optional().describe('Filter by owner user ID'),
+      organizationId: z.string().optional().describe('Filter by organization ID'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+      limit: z.number().optional().describe('Results per page (default: 20)'),
+      sortBy: z.string().optional().describe('Sort field (default: createdAt)'),
+      sortOrder: z.enum(['asc', 'desc']).optional().describe('Sort order (default: desc)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return DealService.findAll({
+        tenantId: auth.tenantId,
+        search: params.search,
+        stage: params.stage as DealStage | undefined,
+        ownerUserId: params.ownerUserId,
+        organizationId: params.organizationId,
+        page: params.page,
+        limit: params.limit,
+        sortBy: params.sortBy,
+        sortOrder: params.sortOrder,
+      });
+    })
+  );
+
+  server.tool(
+    'get_deal',
+    'Get detailed information about a specific deal by ID',
+    {
+      id: z.string().describe('Deal ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return DealService.findById(params.id, auth.tenantId);
+    })
+  );
+
+  server.tool(
+    'create_deal',
+    'Create a new deal (consulting engagement)',
+    {
+      title: z.string().describe('Deal title (required)'),
+      organizationId: z.string().describe('Organization ID (required)'),
+      contactIds: z.array(z.string()).optional().describe('Contact IDs associated with this deal'),
+      amount: z.number().optional().describe('Deal amount'),
+      expectedCloseDate: z.string().optional().describe('Expected close date (ISO format)'),
+      stage: z.enum(['LEAD', 'PROSPECT', 'QUOTE', 'WON', 'LOST']).optional().describe('Deal stage (default: LEAD)'),
+      probability: z.number().optional().describe('Win probability (0-100)'),
+      ownerUserId: z.string().optional().describe('Owner user ID (defaults to current user)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return DealService.create(
+        {
+          title: params.title,
+          organizationId: params.organizationId,
+          contactIds: params.contactIds,
+          amount: params.amount,
+          expectedCloseDate: params.expectedCloseDate,
+          stage: params.stage as DealStage | undefined,
+          probability: params.probability,
+          ownerUserId: params.ownerUserId,
+        },
+        auth.tenantId,
+        auth.userId
+      );
+    })
+  );
+
+  server.tool(
+    'update_deal',
+    'Update an existing deal',
+    {
+      id: z.string().describe('Deal ID'),
+      title: z.string().optional().describe('Deal title'),
+      organizationId: z.string().optional().describe('Organization ID'),
+      contactIds: z.array(z.string()).optional().describe('Contact IDs'),
+      amount: z.number().optional().describe('Deal amount'),
+      currency: z.string().optional().describe('Currency code'),
+      expectedCloseDate: z.string().optional().describe('Expected close date (ISO format)'),
+      stage: z.enum(['LEAD', 'PROSPECT', 'QUOTE', 'WON', 'LOST']).optional().describe('Deal stage'),
+      probability: z.number().optional().describe('Win probability (0-100)'),
+      reasonLost: z.string().optional().describe('Reason for loss (required if stage is LOST)'),
+      ownerUserId: z.string().optional().describe('Owner user ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      const { id, ...data } = params;
+      return DealService.update(
+        id,
+        {
+          ...data,
+          stage: data.stage as DealStage | undefined,
+        },
+        auth.tenantId,
+        auth.userId
+      );
+    })
+  );
+
+  server.tool(
+    'update_deal_stage',
+    'Update the stage of a deal (move through pipeline)',
+    {
+      id: z.string().describe('Deal ID'),
+      stage: z.enum(['LEAD', 'PROSPECT', 'QUOTE', 'WON', 'LOST']).describe('New stage'),
+      reasonLost: z.string().optional().describe('Reason for loss (required if stage is LOST)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return DealService.updateStage(
+        params.id,
+        params.stage as DealStage,
+        params.reasonLost,
+        auth.tenantId,
+        auth.userId
+      );
+    })
+  );
+
+  server.tool(
+    'delete_deal',
+    'Delete a deal',
+    {
+      id: z.string().describe('Deal ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      await DealService.delete(params.id, auth.tenantId, auth.userId);
+      return { success: true, message: 'Deal deleted successfully' };
+    })
+  );
+
+  server.tool(
+    'get_pipeline_summary',
+    'Get a summary of the deal pipeline (count and total amount by stage)',
+    {},
+    wrapToolHandler(async () => {
+      return DealService.getPipeline(auth.tenantId);
+    })
+  );
+}

--- a/backend/src/mcp/tools/notes.ts
+++ b/backend/src/mcp/tools/notes.ts
@@ -1,0 +1,51 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { JWTPayload } from '../../utils/auth';
+import { NoteService } from '../../services/note.service';
+import { NoteEntityType } from '@prisma/client';
+
+export function registerNoteTools(server: McpServer, auth: JWTPayload, wrapToolHandler: any) {
+  server.tool(
+    'create_note',
+    'Create a note attached to an organization, contact, or deal',
+    {
+      content: z.string().describe('Note content (required)'),
+      entityType: z.enum(['ORGANIZATION', 'CONTACT', 'DEAL']).describe('Entity type (required)'),
+      entityId: z.string().describe('Entity ID (required)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return NoteService.create(
+        {
+          content: params.content,
+          entityType: params.entityType as NoteEntityType,
+          entityId: params.entityId,
+        },
+        auth.tenantId,
+        auth.userId
+      );
+    })
+  );
+
+  server.tool(
+    'get_note',
+    'Get a specific note by ID',
+    {
+      id: z.string().describe('Note ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return NoteService.findById(params.id, auth.tenantId);
+    })
+  );
+
+  server.tool(
+    'update_note',
+    'Update a note',
+    {
+      id: z.string().describe('Note ID'),
+      content: z.string().describe('New note content'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return NoteService.update(params.id, params.content, auth.tenantId, auth.userId);
+    })
+  );
+}

--- a/backend/src/mcp/tools/organizations.ts
+++ b/backend/src/mcp/tools/organizations.ts
@@ -1,0 +1,157 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { JWTPayload } from '../../utils/auth';
+import { OrganizationService } from '../../services/organization.service';
+
+export function registerOrganizationTools(server: McpServer, auth: JWTPayload, wrapToolHandler: any) {
+  server.tool(
+    'list_organizations',
+    'List all organizations with optional filtering, search, and pagination',
+    {
+      search: z.string().optional().describe('Search by name, website, or city'),
+      ownerUserId: z.string().optional().describe('Filter by owner user ID'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+      limit: z.number().optional().describe('Results per page (default: 20)'),
+      sortBy: z.string().optional().describe('Sort field (default: createdAt)'),
+      sortOrder: z.enum(['asc', 'desc']).optional().describe('Sort order (default: desc)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return OrganizationService.findAll({
+        tenantId: auth.tenantId,
+        search: params.search,
+        ownerUserId: params.ownerUserId,
+        page: params.page,
+        limit: params.limit,
+        sortBy: params.sortBy,
+        sortOrder: params.sortOrder,
+      });
+    })
+  );
+
+  server.tool(
+    'get_organization',
+    'Get detailed information about a specific organization by ID',
+    {
+      id: z.string().describe('Organization ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return OrganizationService.findById(params.id, auth.tenantId);
+    })
+  );
+
+  server.tool(
+    'create_organization',
+    'Create a new organization',
+    {
+      name: z.string().describe('Organization name (required)'),
+      website: z.string().optional().describe('Website URL'),
+      street: z.string().optional().describe('Street address'),
+      city: z.string().optional().describe('City'),
+      zip: z.string().optional().describe('ZIP code'),
+      country: z.string().optional().describe('Country'),
+      ownerUserId: z.string().optional().describe('Owner user ID (defaults to current user)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return OrganizationService.create(
+        {
+          name: params.name,
+          website: params.website,
+          street: params.street,
+          city: params.city,
+          zip: params.zip,
+          country: params.country,
+          ownerUserId: params.ownerUserId,
+        },
+        auth.tenantId,
+        auth.userId
+      );
+    })
+  );
+
+  server.tool(
+    'update_organization',
+    'Update an existing organization',
+    {
+      id: z.string().describe('Organization ID'),
+      name: z.string().optional().describe('Organization name'),
+      website: z.string().optional().describe('Website URL'),
+      street: z.string().optional().describe('Street address'),
+      city: z.string().optional().describe('City'),
+      zip: z.string().optional().describe('ZIP code'),
+      country: z.string().optional().describe('Country'),
+      ownerUserId: z.string().optional().describe('Owner user ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      const { id, ...data } = params;
+      return OrganizationService.update(id, data, auth.tenantId, auth.userId);
+    })
+  );
+
+  server.tool(
+    'delete_organization',
+    'Delete an organization',
+    {
+      id: z.string().describe('Organization ID'),
+    },
+    wrapToolHandler(async (params: any) => {
+      await OrganizationService.delete(params.id, auth.tenantId, auth.userId);
+      return { success: true, message: 'Organization deleted successfully' };
+    })
+  );
+
+  server.tool(
+    'get_organization_contacts',
+    'Get all contacts associated with an organization',
+    {
+      organizationId: z.string().describe('Organization ID'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+      limit: z.number().optional().describe('Results per page (default: 20)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return OrganizationService.getContacts(
+        params.organizationId,
+        auth.tenantId,
+        params.page,
+        params.limit
+      );
+    })
+  );
+
+  server.tool(
+    'get_organization_deals',
+    'Get all deals associated with an organization',
+    {
+      organizationId: z.string().describe('Organization ID'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+      limit: z.number().optional().describe('Results per page (default: 20)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return OrganizationService.getDeals(
+        params.organizationId,
+        auth.tenantId,
+        params.page,
+        params.limit
+      );
+    })
+  );
+
+  server.tool(
+    'get_organization_activities',
+    'Get all activities associated with an organization',
+    {
+      organizationId: z.string().describe('Organization ID'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+      limit: z.number().optional().describe('Results per page (default: 20)'),
+      isCompleted: z.boolean().optional().describe('Filter by completion status'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return OrganizationService.getActivities(
+        params.organizationId,
+        auth.tenantId,
+        params.page,
+        params.limit,
+        params.isCompleted
+      );
+    })
+  );
+}

--- a/backend/src/mcp/tools/reports.ts
+++ b/backend/src/mcp/tools/reports.ts
@@ -1,0 +1,67 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { JWTPayload } from '../../utils/auth';
+import { ReportService } from '../../services/report.service';
+
+export function registerReportTools(server: McpServer, auth: JWTPayload, wrapToolHandler: any) {
+  server.tool(
+    'get_pipeline_report',
+    'Get pipeline summary report (count and total value by stage)',
+    {},
+    wrapToolHandler(async () => {
+      return ReportService.getPipelineSummary(auth.tenantId);
+    })
+  );
+
+  server.tool(
+    'get_win_rate_report',
+    'Get win rate report (won vs lost deals, average deal size)',
+    {},
+    wrapToolHandler(async () => {
+      return ReportService.getWinRate(auth.tenantId);
+    })
+  );
+
+  server.tool(
+    'get_cycle_time_report',
+    'Get cycle time report (average and median days from creation to close)',
+    {},
+    wrapToolHandler(async () => {
+      return ReportService.getCycleTime(auth.tenantId);
+    })
+  );
+
+  server.tool(
+    'get_activity_volume_report',
+    'Get activity volume report (count and completion rate by activity type)',
+    {
+      startDate: z.string().optional().describe('Start date (ISO format)'),
+      endDate: z.string().optional().describe('End date (ISO format)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      const startDate = params.startDate ? new Date(params.startDate) : undefined;
+      const endDate = params.endDate ? new Date(params.endDate) : undefined;
+      return ReportService.getActivityVolume(auth.tenantId, startDate, endDate);
+    })
+  );
+
+  server.tool(
+    'get_top_accounts_report',
+    'Get top accounts report (organizations with highest total revenue)',
+    {
+      limit: z.number().optional().describe('Number of top accounts to return (default: 10)'),
+    },
+    wrapToolHandler(async (params: any) => {
+      return ReportService.getTopAccounts(auth.tenantId, params.limit);
+    })
+  );
+
+  server.tool(
+    'get_forecast_report',
+    'Get forecast report (projected revenue by month based on expected close dates and probabilities)',
+    {},
+    wrapToolHandler(async () => {
+      return ReportService.getForecast(auth.tenantId);
+    })
+  );
+}

--- a/backend/src/mcp/transport.ts
+++ b/backend/src/mcp/transport.ts
@@ -1,0 +1,206 @@
+import { Router, Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { verifyAccessToken, JWTPayload } from '../utils/auth';
+import { logger } from '../utils/logger';
+import { createMcpServer } from './server';
+
+interface McpSession {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+  auth: JWTPayload;
+  lastActivity: number;
+}
+
+const sessions = new Map<string, McpSession>();
+
+// Session timeout: 30 minutes
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // Check every 5 minutes
+
+/**
+ * Extract and verify JWT from Authorization header
+ */
+function extractAuth(req: Request): JWTPayload | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authHeader.substring(7);
+  try {
+    return verifyAccessToken(token);
+  } catch (error) {
+    logger.error('JWT verification failed:', error);
+    return null;
+  }
+}
+
+/**
+ * Create Express router with MCP transport handlers
+ */
+export function createMcpRouter(): Router {
+  const router = Router();
+
+  // POST handler - handles MCP requests
+  router.post('/', async (req: Request, res: Response) => {
+    try {
+      const auth = extractAuth(req);
+      if (!auth) {
+        const proto = req.headers['x-forwarded-proto'] || req.protocol;
+        const host = req.headers['x-forwarded-host'] || req.get('host');
+        const baseUrl = process.env.BASE_URL || `${proto}://${host}`;
+        res.status(401)
+          .set('WWW-Authenticate', `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`)
+          .json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+      let session: McpSession;
+
+      if (!sessionId) {
+        // Create new session
+        const newSessionId = randomUUID();
+        const server = createMcpServer(auth);
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => newSessionId,
+        });
+        await server.connect(transport);
+
+        session = {
+          transport,
+          server,
+          auth,
+          lastActivity: Date.now(),
+        };
+
+        sessions.set(newSessionId, session);
+        logger.info(`Created MCP session ${newSessionId} for user ${auth.email}`);
+      } else {
+        // Look up existing session
+        session = sessions.get(sessionId)!;
+        if (!session) {
+          res.status(400).json({ error: 'Session not found' });
+          return;
+        }
+
+        // Verify session belongs to same user
+        if (session.auth.userId !== auth.userId || session.auth.tenantId !== auth.tenantId) {
+          res.status(403).json({ error: 'Session does not belong to this user' });
+          return;
+        }
+
+        // Update last activity
+        session.lastActivity = Date.now();
+      }
+
+      // Delegate to transport
+      await session.transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      logger.error('MCP POST handler error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  // GET handler - handles SSE stream for server-initiated messages
+  router.get('/', async (req: Request, res: Response) => {
+    try {
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      if (!sessionId) {
+        res.status(400).json({ error: 'Missing mcp-session-id header' });
+        return;
+      }
+
+      const session = sessions.get(sessionId);
+      if (!session) {
+        res.status(404).json({ error: 'Session not found' });
+        return;
+      }
+
+      session.lastActivity = Date.now();
+      await session.transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      logger.error('MCP GET handler error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  // DELETE handler - terminates session
+  router.delete('/', async (req: Request, res: Response) => {
+    try {
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      if (!sessionId) {
+        res.status(400).json({ error: 'Missing mcp-session-id header' });
+        return;
+      }
+
+      const session = sessions.get(sessionId);
+      if (!session) {
+        res.status(404).json({ error: 'Session not found' });
+        return;
+      }
+
+      await session.transport.handleRequest(req, res, req.body);
+      await session.transport.close();
+      sessions.delete(sessionId);
+      logger.info(`Terminated MCP session ${sessionId}`);
+
+      res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error('MCP DELETE handler error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  return router;
+}
+
+/**
+ * Close all active MCP sessions (for graceful shutdown)
+ */
+export async function closeAllSessions(): Promise<void> {
+  logger.info(`Closing ${sessions.size} active MCP sessions...`);
+  const closePromises: Promise<void>[] = [];
+
+  for (const [sessionId, session] of sessions.entries()) {
+    closePromises.push(
+      session.transport.close().catch((error) => {
+        logger.error(`Error closing session ${sessionId}:`, error);
+      })
+    );
+  }
+
+  await Promise.allSettled(closePromises);
+  sessions.clear();
+  logger.info('All MCP sessions closed');
+}
+
+/**
+ * Cleanup interval - remove stale sessions
+ */
+setInterval(() => {
+  const now = Date.now();
+  const staleSessionIds: string[] = [];
+
+  for (const [sessionId, session] of sessions.entries()) {
+    if (now - session.lastActivity > SESSION_TIMEOUT_MS) {
+      staleSessionIds.push(sessionId);
+    }
+  }
+
+  if (staleSessionIds.length > 0) {
+    logger.info(`Cleaning up ${staleSessionIds.length} stale MCP sessions`);
+    for (const sessionId of staleSessionIds) {
+      const session = sessions.get(sessionId);
+      if (session) {
+        session.transport.close().catch((error) => {
+          logger.error(`Error closing stale session ${sessionId}:`, error);
+        });
+        sessions.delete(sessionId);
+      }
+    }
+  }
+}, CLEANUP_INTERVAL_MS);

--- a/backend/src/oauth/index.ts
+++ b/backend/src/oauth/index.ts
@@ -1,0 +1,41 @@
+import { Express, Request } from 'express';
+import { createOAuthRouter } from './routes';
+
+function getBaseUrl(req: Request): string {
+  if (process.env.BASE_URL) return process.env.BASE_URL;
+  const proto = req.headers['x-forwarded-proto'] || req.protocol;
+  const host = req.headers['x-forwarded-host'] || req.get('host');
+  return `${proto}://${host}`;
+}
+
+export function mountOAuth(app: Express): void {
+  // RFC 9728: Protected Resource Metadata
+  app.get('/.well-known/oauth-protected-resource', (req, res) => {
+    const baseUrl = getBaseUrl(req);
+    res.json({
+      resource: baseUrl,
+      authorization_servers: [baseUrl],
+      bearer_methods_supported: ['header'],
+      scopes_supported: ['crm:read', 'crm:write'],
+    });
+  });
+
+  // RFC 8414: OAuth Authorization Server Metadata
+  app.get('/.well-known/oauth-authorization-server', (req, res) => {
+    const baseUrl = getBaseUrl(req);
+    res.json({
+      issuer: baseUrl,
+      authorization_endpoint: `${baseUrl}/oauth/authorize`,
+      token_endpoint: `${baseUrl}/oauth/token`,
+      registration_endpoint: `${baseUrl}/oauth/register`,
+      scopes_supported: ['crm:read', 'crm:write'],
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      token_endpoint_auth_methods_supported: ['none'],
+      code_challenge_methods_supported: ['S256'],
+    });
+  });
+
+  // Mount OAuth routes
+  app.use('/oauth', createOAuthRouter());
+}

--- a/backend/src/oauth/routes.ts
+++ b/backend/src/oauth/routes.ts
@@ -1,0 +1,272 @@
+import { Router, Request, Response } from 'express';
+import cors from 'cors';
+import { OAuthService } from './service';
+import { renderLoginPage, renderConsentPage, renderErrorPage } from './views';
+import {
+  clientRegistrationSchema,
+  authorizeQuerySchema,
+  loginFormSchema,
+  consentFormSchema,
+  tokenRequestSchema,
+} from './validation';
+import { logger } from '../utils/logger';
+import { AppError } from '../middleware/errorHandler';
+
+/**
+ * Create OAuth router
+ */
+export function createOAuthRouter(): Router {
+  const router = Router();
+
+  // Enable CORS for /register and /token endpoints (Claude makes cross-origin requests)
+  const corsOptions = { origin: true };
+
+  /**
+   * POST /oauth/register - Dynamic Client Registration
+   */
+  router.post('/register', cors(corsOptions), async (req: Request, res: Response) => {
+    try {
+      const data = clientRegistrationSchema.parse(req.body);
+
+      const client = await OAuthService.registerClient(data);
+
+      res.status(201).json({
+        client_id: client.clientId,
+        client_name: client.clientName,
+        redirect_uris: client.redirectUris,
+        grant_types: client.grantTypes,
+        token_endpoint_auth_method: 'none',
+      });
+    } catch (error) {
+      logger.error('Client registration error:', error);
+
+      if (error instanceof AppError) {
+        res.status(error.statusCode).json({ error: error.message });
+      } else if (error instanceof Error && 'issues' in error) {
+        // Zod validation error
+        res.status(400).json({ error: 'Validation error', details: error });
+      } else {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  });
+
+  /**
+   * GET /oauth/authorize - Login Page
+   */
+  router.get('/authorize', async (req: Request, res: Response) => {
+    try {
+      const params = authorizeQuerySchema.parse(req.query);
+
+      const client = await OAuthService.validateClient(params.client_id, params.redirect_uri);
+
+      const html = renderLoginPage({
+        clientId: params.client_id,
+        redirectUri: params.redirect_uri,
+        codeChallenge: params.code_challenge,
+        codeChallengeMethod: params.code_challenge_method,
+        state: params.state,
+        scope: params.scope,
+        clientName: client.clientName,
+      });
+
+      res.removeHeader('Content-Security-Policy');
+      res.setHeader('Content-Type', 'text/html');
+      res.send(html);
+    } catch (error) {
+      logger.error('Authorization page error:', error);
+
+      const errorHtml = renderErrorPage(
+        'Authorization Error',
+        error instanceof AppError ? error.message : 'Invalid authorization request'
+      );
+
+      res.removeHeader('Content-Security-Policy');
+      res.setHeader('Content-Type', 'text/html');
+      res.status(400).send(errorHtml);
+    }
+  });
+
+  /**
+   * POST /oauth/authorize - Login Form Submit
+   */
+  router.post('/authorize', async (req: Request, res: Response) => {
+    try {
+      const data = loginFormSchema.parse(req.body);
+
+      // Authenticate user
+      const user = await OAuthService.authenticateUser(data.email, data.password);
+
+      // Validate client
+      const client = await OAuthService.validateClient(data.client_id, data.redirect_uri);
+
+      // Generate auth session token
+      const authSessionToken = OAuthService.generateAuthSessionToken({
+        userId: user.id,
+        tenantId: user.tenantId,
+        email: user.email,
+        role: user.role,
+      });
+
+      // Render consent page
+      const userName = user.firstName && user.lastName
+        ? `${user.firstName} ${user.lastName}`
+        : user.email;
+
+      const html = renderConsentPage({
+        clientName: client.clientName,
+        scope: data.scope,
+        authSessionToken,
+        clientId: data.client_id,
+        redirectUri: data.redirect_uri,
+        codeChallenge: data.code_challenge,
+        codeChallengeMethod: data.code_challenge_method,
+        state: data.state,
+        userName,
+      });
+
+      res.removeHeader('Content-Security-Policy');
+      res.setHeader('Content-Type', 'text/html');
+      res.send(html);
+    } catch (error) {
+      logger.error('Login error:', error);
+
+      // Re-render login page with error
+      try {
+        const data = loginFormSchema.parse(req.body);
+        const client = await OAuthService.validateClient(data.client_id, data.redirect_uri);
+
+        const errorMessage = error instanceof AppError
+          ? error.message
+          : 'An error occurred during login. Please try again.';
+
+        const html = renderLoginPage({
+          clientId: data.client_id,
+          redirectUri: data.redirect_uri,
+          codeChallenge: data.code_challenge,
+          codeChallengeMethod: data.code_challenge_method,
+          state: data.state,
+          scope: data.scope,
+          clientName: client.clientName,
+          error: errorMessage,
+        });
+
+        res.removeHeader('Content-Security-Policy');
+        res.setHeader('Content-Type', 'text/html');
+        res.status(401).send(html);
+      } catch (renderError) {
+        logger.error('Error rendering login page:', renderError);
+        const errorHtml = renderErrorPage('Error', 'An unexpected error occurred');
+        res.removeHeader('Content-Security-Policy');
+        res.setHeader('Content-Type', 'text/html');
+        res.status(500).send(errorHtml);
+      }
+    }
+  });
+
+  /**
+   * POST /oauth/authorize/consent - Consent Decision
+   */
+  router.post('/authorize/consent', async (req: Request, res: Response) => {
+    try {
+      const data = consentFormSchema.parse(req.body);
+
+      // Verify auth session token
+      const authPayload = OAuthService.verifyAuthSessionToken(data.auth_session_token);
+
+      // Validate client
+      await OAuthService.validateClient(data.client_id, data.redirect_uri);
+
+      if (data.decision === 'deny') {
+        // User denied consent - redirect with error
+        const url = new URL(data.redirect_uri);
+        url.searchParams.set('error', 'access_denied');
+        if (data.state) {
+          url.searchParams.set('state', data.state);
+        }
+        res.redirect(url.toString());
+        return;
+      }
+
+      // User allowed - create authorization code
+      const code = await OAuthService.createAuthorizationCode({
+        clientId: data.client_id,
+        userId: authPayload.userId,
+        tenantId: authPayload.tenantId,
+        redirectUri: data.redirect_uri,
+        codeChallenge: data.code_challenge,
+        codeChallengeMethod: data.code_challenge_method,
+        scope: data.scope,
+        state: data.state,
+      });
+
+      // Redirect with authorization code
+      const url = new URL(data.redirect_uri);
+      url.searchParams.set('code', code);
+      if (data.state) {
+        url.searchParams.set('state', data.state);
+      }
+
+      res.redirect(url.toString());
+    } catch (error) {
+      logger.error('Consent error:', error);
+
+      const errorHtml = renderErrorPage(
+        'Consent Error',
+        error instanceof AppError ? error.message : 'An error occurred processing your consent'
+      );
+
+      res.removeHeader('Content-Security-Policy');
+      res.setHeader('Content-Type', 'text/html');
+      res.status(400).send(errorHtml);
+    }
+  });
+
+  /**
+   * POST /oauth/token - Token Exchange
+   */
+  router.post('/token', cors(corsOptions), async (req: Request, res: Response) => {
+    try {
+      const data = tokenRequestSchema.parse(req.body);
+
+      if (data.grant_type === 'authorization_code') {
+        if (!data.code || !data.code_verifier || !data.redirect_uri) {
+          res.status(400).json({ error: 'invalid_request', error_description: 'Missing required parameters' });
+          return;
+        }
+
+        const result = await OAuthService.exchangeCode(
+          data.code,
+          data.code_verifier,
+          data.client_id,
+          data.redirect_uri
+        );
+
+        res.json(result);
+      } else if (data.grant_type === 'refresh_token') {
+        if (!data.refresh_token) {
+          res.status(400).json({ error: 'invalid_request', error_description: 'Missing refresh_token' });
+          return;
+        }
+
+        const result = await OAuthService.refreshAccessToken(data.refresh_token, data.client_id);
+
+        res.json(result);
+      } else {
+        res.status(400).json({ error: 'unsupported_grant_type' });
+      }
+    } catch (error) {
+      logger.error('Token error:', error);
+
+      if (error instanceof AppError) {
+        res.status(400).json({ error: 'invalid_grant', error_description: error.message });
+      } else if (error instanceof Error && 'issues' in error) {
+        res.status(400).json({ error: 'invalid_request', error_description: 'Validation error' });
+      } else {
+        res.status(500).json({ error: 'server_error', error_description: 'Internal server error' });
+      }
+    }
+  });
+
+  return router;
+}

--- a/backend/src/oauth/service.ts
+++ b/backend/src/oauth/service.ts
@@ -1,0 +1,322 @@
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import prisma from '../config/database';
+import { verifyPassword, generateAccessToken, hashToken, JWTPayload } from '../utils/auth';
+import { AppError } from '../middleware/errorHandler';
+
+interface ClientRegistrationData {
+  client_name: string;
+  redirect_uris: string[];
+  grant_types: string[];
+  token_endpoint_auth_method: string;
+}
+
+interface AuthCodeParams {
+  clientId: string;
+  userId: string;
+  tenantId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scope?: string;
+  state?: string;
+}
+
+interface AuthSessionPayload {
+  userId: string;
+  tenantId: string;
+  email: string;
+  role: string;
+}
+
+export class OAuthService {
+  /**
+   * Register a new OAuth client
+   */
+  static async registerClient(data: ClientRegistrationData) {
+    const clientId = crypto.randomUUID();
+
+    const client = await prisma.oAuthClient.create({
+      data: {
+        clientId,
+        clientSecret: null, // Public client (no secret)
+        clientName: data.client_name,
+        redirectUris: data.redirect_uris,
+        grantTypes: data.grant_types,
+        scope: null,
+      },
+    });
+
+    return client;
+  }
+
+  /**
+   * Validate client and redirect URI
+   */
+  static async validateClient(clientId: string, redirectUri: string) {
+    const client = await prisma.oAuthClient.findUnique({
+      where: { clientId },
+    });
+
+    if (!client) {
+      throw new AppError(400, 'Invalid client_id');
+    }
+
+    if (!client.redirectUris.includes(redirectUri)) {
+      throw new AppError(400, 'Invalid redirect_uri');
+    }
+
+    return client;
+  }
+
+  /**
+   * Authenticate user with email and password
+   */
+  static async authenticateUser(email: string, password: string) {
+    const user = await prisma.user.findFirst({
+      where: {
+        email: {
+          equals: email,
+          mode: 'insensitive',
+        },
+      },
+      include: {
+        tenant: true,
+      },
+    });
+
+    if (!user) {
+      throw new AppError(401, 'Invalid credentials');
+    }
+
+    if (!user.isActive) {
+      throw new AppError(401, 'Account is inactive');
+    }
+
+    const isPasswordValid = await verifyPassword(password, user.passwordHash);
+    if (!isPasswordValid) {
+      throw new AppError(401, 'Invalid credentials');
+    }
+
+    return user;
+  }
+
+  /**
+   * Generate short-lived auth session token
+   */
+  static generateAuthSessionToken(payload: AuthSessionPayload): string {
+    const token = jwt.sign(payload, process.env.JWT_SECRET!, {
+      expiresIn: '2m',
+    });
+    return token;
+  }
+
+  /**
+   * Verify auth session token
+   */
+  static verifyAuthSessionToken(token: string): AuthSessionPayload {
+    try {
+      const payload = jwt.verify(token, process.env.JWT_SECRET!) as AuthSessionPayload;
+      return payload;
+    } catch (error) {
+      throw new AppError(401, 'Invalid or expired auth session');
+    }
+  }
+
+  /**
+   * Create authorization code
+   */
+  static async createAuthorizationCode(params: AuthCodeParams) {
+    const code = crypto.randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes
+
+    await prisma.oAuthAuthorizationCode.create({
+      data: {
+        code,
+        clientId: params.clientId,
+        userId: params.userId,
+        tenantId: params.tenantId,
+        redirectUri: params.redirectUri,
+        codeChallenge: params.codeChallenge,
+        codeChallengeMethod: params.codeChallengeMethod,
+        scope: params.scope || null,
+        state: params.state || null,
+        expiresAt,
+      },
+    });
+
+    return code;
+  }
+
+  /**
+   * Verify PKCE challenge
+   */
+  private static verifyPKCE(codeVerifier: string, codeChallenge: string): boolean {
+    const hash = crypto.createHash('sha256').update(codeVerifier).digest();
+    const computed = hash.toString('base64url');
+    return computed === codeChallenge;
+  }
+
+  /**
+   * Exchange authorization code for access token
+   */
+  static async exchangeCode(
+    code: string,
+    codeVerifier: string,
+    clientId: string,
+    redirectUri: string
+  ) {
+    // Look up authorization code
+    const authCode = await prisma.oAuthAuthorizationCode.findUnique({
+      where: { code },
+    });
+
+    if (!authCode) {
+      throw new AppError(400, 'Invalid authorization code');
+    }
+
+    // Check if already used
+    if (authCode.usedAt) {
+      throw new AppError(400, 'Authorization code already used');
+    }
+
+    // Check expiration
+    if (authCode.expiresAt < new Date()) {
+      throw new AppError(400, 'Authorization code expired');
+    }
+
+    // Verify client ID
+    if (authCode.clientId !== clientId) {
+      throw new AppError(400, 'Client ID mismatch');
+    }
+
+    // Verify redirect URI
+    if (authCode.redirectUri !== redirectUri) {
+      throw new AppError(400, 'Redirect URI mismatch');
+    }
+
+    // Verify PKCE
+    if (!this.verifyPKCE(codeVerifier, authCode.codeChallenge)) {
+      throw new AppError(400, 'Invalid code verifier');
+    }
+
+    // Mark code as used
+    await prisma.oAuthAuthorizationCode.update({
+      where: { code },
+      data: { usedAt: new Date() },
+    });
+
+    // Look up user
+    const user = await prisma.user.findUnique({
+      where: { id: authCode.userId },
+    });
+
+    if (!user || !user.isActive) {
+      throw new AppError(401, 'User not found or inactive');
+    }
+
+    // Generate access token
+    const accessToken = generateAccessToken({
+      userId: user.id,
+      tenantId: user.tenantId,
+      email: user.email,
+      role: user.role,
+    });
+
+    // Generate OAuth refresh token
+    const refreshToken = crypto.randomBytes(32).toString('hex');
+    const refreshTokenHash = hashToken(refreshToken);
+    const refreshExpiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
+
+    await prisma.oAuthRefreshToken.create({
+      data: {
+        tokenHash: refreshTokenHash,
+        clientId,
+        userId: user.id,
+        tenantId: user.tenantId,
+        scope: authCode.scope,
+        expiresAt: refreshExpiresAt,
+      },
+    });
+
+    return {
+      access_token: accessToken,
+      token_type: 'bearer',
+      expires_in: 900, // 15 minutes
+      refresh_token: refreshToken,
+      scope: authCode.scope || 'crm:read crm:write',
+    };
+  }
+
+  /**
+   * Refresh access token
+   */
+  static async refreshAccessToken(refreshToken: string, clientId: string) {
+    const tokenHash = hashToken(refreshToken);
+
+    // Look up refresh token
+    const storedToken = await prisma.oAuthRefreshToken.findUnique({
+      where: { tokenHash },
+    });
+
+    if (!storedToken) {
+      throw new AppError(400, 'Invalid refresh token');
+    }
+
+    // Check expiration
+    if (storedToken.expiresAt < new Date()) {
+      throw new AppError(400, 'Refresh token expired');
+    }
+
+    // Verify client ID
+    if (storedToken.clientId !== clientId) {
+      throw new AppError(400, 'Client ID mismatch');
+    }
+
+    // Look up user
+    const user = await prisma.user.findUnique({
+      where: { id: storedToken.userId },
+    });
+
+    if (!user || !user.isActive) {
+      throw new AppError(401, 'User not found or inactive');
+    }
+
+    // Generate new access token
+    const accessToken = generateAccessToken({
+      userId: user.id,
+      tenantId: user.tenantId,
+      email: user.email,
+      role: user.role,
+    });
+
+    // Rotate refresh token (delete old, create new)
+    const newRefreshToken = crypto.randomBytes(32).toString('hex');
+    const newTokenHash = hashToken(newRefreshToken);
+    const newExpiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+    await prisma.$transaction([
+      prisma.oAuthRefreshToken.delete({
+        where: { tokenHash },
+      }),
+      prisma.oAuthRefreshToken.create({
+        data: {
+          tokenHash: newTokenHash,
+          clientId,
+          userId: user.id,
+          tenantId: user.tenantId,
+          scope: storedToken.scope,
+          expiresAt: newExpiresAt,
+        },
+      }),
+    ]);
+
+    return {
+      access_token: accessToken,
+      token_type: 'bearer',
+      expires_in: 900,
+      refresh_token: newRefreshToken,
+      scope: storedToken.scope || 'crm:read crm:write',
+    };
+  }
+}

--- a/backend/src/oauth/validation.ts
+++ b/backend/src/oauth/validation.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+// POST /oauth/register - Dynamic Client Registration
+export const clientRegistrationSchema = z.object({
+  client_name: z.string().min(1, 'Client name is required'),
+  redirect_uris: z.array(z.string().url('Invalid redirect URI')).min(1, 'At least one redirect URI is required'),
+  grant_types: z.array(z.string()).optional().default(['authorization_code']),
+  token_endpoint_auth_method: z.string().optional().default('none'),
+});
+
+// GET /oauth/authorize - Authorization Request
+export const authorizeQuerySchema = z.object({
+  response_type: z.literal('code'),
+  client_id: z.string().min(1, 'Client ID is required'),
+  redirect_uri: z.string().url('Invalid redirect URI'),
+  code_challenge: z.string().min(1, 'Code challenge is required'),
+  code_challenge_method: z.literal('S256'),
+  state: z.string().optional(),
+  scope: z.string().optional(),
+});
+
+// POST /oauth/authorize - Login Form Submit
+export const loginFormSchema = z.object({
+  email: z.string().email('Invalid email address'),
+  password: z.string().min(1, 'Password is required'),
+  client_id: z.string().min(1),
+  redirect_uri: z.string().url(),
+  code_challenge: z.string().min(1),
+  code_challenge_method: z.literal('S256'),
+  state: z.string().optional(),
+  scope: z.string().optional(),
+});
+
+// POST /oauth/authorize/consent - Consent Decision
+export const consentFormSchema = z.object({
+  auth_session_token: z.string().min(1, 'Auth session token is required'),
+  decision: z.enum(['allow', 'deny']),
+  client_id: z.string().min(1),
+  redirect_uri: z.string().url(),
+  code_challenge: z.string().min(1),
+  code_challenge_method: z.literal('S256'),
+  state: z.string().optional(),
+  scope: z.string().optional(),
+});
+
+// POST /oauth/token - Token Request
+export const tokenRequestSchema = z.object({
+  grant_type: z.enum(['authorization_code', 'refresh_token']),
+  code: z.string().optional(),
+  redirect_uri: z.string().optional(),
+  code_verifier: z.string().optional(),
+  client_id: z.string().min(1, 'Client ID is required'),
+  refresh_token: z.string().optional(),
+});

--- a/backend/src/oauth/views.ts
+++ b/backend/src/oauth/views.ts
@@ -1,0 +1,224 @@
+interface LoginPageParams {
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  state?: string;
+  scope?: string;
+  clientName: string;
+  error?: string;
+}
+
+interface ConsentPageParams {
+  clientName: string;
+  scope?: string;
+  authSessionToken: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  state?: string;
+  userName: string;
+}
+
+/**
+ * Render login page with dark theme
+ */
+export function renderLoginPage(params: LoginPageParams): string {
+  const errorHtml = params.error
+    ? `<div style="background-color: #7f1d1d; border: 1px solid #dc2626; color: #fca5a5; padding: 12px; border-radius: 8px; margin-bottom: 20px; font-size: 14px;">${escapeHtml(params.error)}</div>`
+    : '';
+
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sign in to SpecterCRM</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background-color: #0f172a; color: #ffffff; min-height: 100vh; display: flex; align-items: center; justify-content: center;">
+  <div style="width: 100%; max-width: 420px; padding: 24px;">
+    <div style="background-color: #1e293b; border-radius: 12px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3); padding: 40px;">
+      <div style="text-align: center; margin-bottom: 32px;">
+        <h1 style="margin: 0 0 8px 0; font-size: 32px; font-weight: 700; color: #3b82f6;">SpecterCRM</h1>
+        <h2 style="margin: 0 0 8px 0; font-size: 20px; font-weight: 600; color: #ffffff;">Sign in to continue</h2>
+        <p style="margin: 0; font-size: 14px; color: #94a3b8;">Authorize ${escapeHtml(params.clientName)} to access your CRM data</p>
+      </div>
+
+      ${errorHtml}
+
+      <form method="POST" action="/oauth/authorize">
+        <div style="margin-bottom: 20px;">
+          <label for="email" style="display: block; margin-bottom: 8px; font-size: 14px; font-weight: 500; color: #e2e8f0;">Email</label>
+          <input
+            type="email"
+            id="email"
+            name="email"
+            required
+            style="width: 100%; padding: 12px; font-size: 14px; background-color: #334155; color: #ffffff; border: 1px solid #475569; border-radius: 8px; outline: none; box-sizing: border-box;"
+          />
+        </div>
+
+        <div style="margin-bottom: 24px;">
+          <label for="password" style="display: block; margin-bottom: 8px; font-size: 14px; font-weight: 500; color: #e2e8f0;">Password</label>
+          <input
+            type="password"
+            id="password"
+            name="password"
+            required
+            style="width: 100%; padding: 12px; font-size: 14px; background-color: #334155; color: #ffffff; border: 1px solid #475569; border-radius: 8px; outline: none; box-sizing: border-box;"
+          />
+        </div>
+
+        <input type="hidden" name="client_id" value="${escapeHtml(params.clientId)}" />
+        <input type="hidden" name="redirect_uri" value="${escapeHtml(params.redirectUri)}" />
+        <input type="hidden" name="code_challenge" value="${escapeHtml(params.codeChallenge)}" />
+        <input type="hidden" name="code_challenge_method" value="${escapeHtml(params.codeChallengeMethod)}" />
+        ${params.state ? `<input type="hidden" name="state" value="${escapeHtml(params.state)}" />` : ''}
+        ${params.scope ? `<input type="hidden" name="scope" value="${escapeHtml(params.scope)}" />` : ''}
+
+        <button
+          type="submit"
+          style="width: 100%; padding: 12px; font-size: 16px; font-weight: 600; color: #ffffff; background-color: #3b82f6; border: none; border-radius: 8px; cursor: pointer; transition: background-color 0.2s;"
+          onmouseover="this.style.backgroundColor='#2563eb'"
+          onmouseout="this.style.backgroundColor='#3b82f6'"
+        >
+          Sign in
+        </button>
+      </form>
+    </div>
+  </div>
+</body>
+</html>
+  `;
+}
+
+/**
+ * Render consent page with dark theme
+ */
+export function renderConsentPage(params: ConsentPageParams): string {
+  const scopes = params.scope?.split(' ') || ['crm:read', 'crm:write'];
+  const scopeDescriptions: Record<string, string> = {
+    'crm:read': 'Read your CRM data',
+    'crm:write': 'Create and modify CRM data',
+  };
+
+  const scopeListHtml = scopes
+    .map(scope => {
+      const description = scopeDescriptions[scope] || scope;
+      return `<li style="margin-bottom: 8px; color: #cbd5e1; font-size: 14px;">✓ ${escapeHtml(description)}</li>`;
+    })
+    .join('');
+
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Authorize Access - SpecterCRM</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background-color: #0f172a; color: #ffffff; min-height: 100vh; display: flex; align-items: center; justify-content: center;">
+  <div style="width: 100%; max-width: 480px; padding: 24px;">
+    <div style="background-color: #1e293b; border-radius: 12px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3); padding: 40px;">
+      <div style="text-align: center; margin-bottom: 32px;">
+        <h1 style="margin: 0 0 8px 0; font-size: 28px; font-weight: 700; color: #ffffff;">Authorize Access</h1>
+        <p style="margin: 0 0 16px 0; font-size: 16px; color: #94a3b8;">${escapeHtml(params.clientName)} wants to access your SpecterCRM data</p>
+        <div style="background-color: #334155; padding: 12px; border-radius: 8px; margin-top: 16px;">
+          <p style="margin: 0; font-size: 14px; color: #cbd5e1;">Signed in as <strong>${escapeHtml(params.userName)}</strong></p>
+        </div>
+      </div>
+
+      <div style="margin-bottom: 32px;">
+        <h3 style="margin: 0 0 12px 0; font-size: 16px; font-weight: 600; color: #e2e8f0;">This application will be able to:</h3>
+        <ul style="margin: 0; padding-left: 0; list-style: none;">
+          ${scopeListHtml}
+        </ul>
+      </div>
+
+      <form method="POST" action="/oauth/authorize/consent" style="display: flex; gap: 12px;">
+        <input type="hidden" name="auth_session_token" value="${escapeHtml(params.authSessionToken)}" />
+        <input type="hidden" name="client_id" value="${escapeHtml(params.clientId)}" />
+        <input type="hidden" name="redirect_uri" value="${escapeHtml(params.redirectUri)}" />
+        <input type="hidden" name="code_challenge" value="${escapeHtml(params.codeChallenge)}" />
+        <input type="hidden" name="code_challenge_method" value="${escapeHtml(params.codeChallengeMethod)}" />
+        ${params.state ? `<input type="hidden" name="state" value="${escapeHtml(params.state)}" />` : ''}
+        ${params.scope ? `<input type="hidden" name="scope" value="${escapeHtml(params.scope)}" />` : ''}
+
+        <button
+          type="submit"
+          name="decision"
+          value="deny"
+          style="flex: 1; padding: 12px; font-size: 16px; font-weight: 600; color: #ffffff; background-color: #475569; border: none; border-radius: 8px; cursor: pointer; transition: background-color 0.2s;"
+          onmouseover="this.style.backgroundColor='#64748b'"
+          onmouseout="this.style.backgroundColor='#475569'"
+        >
+          Deny
+        </button>
+
+        <button
+          type="submit"
+          name="decision"
+          value="allow"
+          style="flex: 1; padding: 12px; font-size: 16px; font-weight: 600; color: #ffffff; background-color: #3b82f6; border: none; border-radius: 8px; cursor: pointer; transition: background-color 0.2s;"
+          onmouseover="this.style.backgroundColor='#2563eb'"
+          onmouseout="this.style.backgroundColor='#3b82f6'"
+        >
+          Allow
+        </button>
+      </form>
+    </div>
+  </div>
+</body>
+</html>
+  `;
+}
+
+/**
+ * Render error page with dark theme
+ */
+export function renderErrorPage(title: string, message: string): string {
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(title)} - SpecterCRM</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background-color: #0f172a; color: #ffffff; min-height: 100vh; display: flex; align-items: center; justify-content: center;">
+  <div style="width: 100%; max-width: 480px; padding: 24px;">
+    <div style="background-color: #1e293b; border-radius: 12px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3); padding: 40px; text-align: center;">
+      <div style="font-size: 64px; margin-bottom: 16px;">⚠️</div>
+      <h1 style="margin: 0 0 16px 0; font-size: 28px; font-weight: 700; color: #ffffff;">${escapeHtml(title)}</h1>
+      <p style="margin: 0; font-size: 16px; color: #94a3b8; line-height: 1.6;">${escapeHtml(message)}</p>
+    </div>
+  </div>
+</body>
+</html>
+  `;
+}
+
+/**
+ * Escape HTML to prevent XSS
+ */
+function escapeHtml(text: string): string {
+  const map: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;',
+  };
+  return text.replace(/[&<>"']/g, (m) => map[m]);
+}


### PR DESCRIPTION
## Summary
- Adds Streamable HTTP MCP endpoint at `/mcp` with 35 tools (CRUD for organizations, contacts, deals, activities, notes + reports)
- Implements OAuth 2.1 authorization server with PKCE so SpecterCRM works as a Claude Connector
- Users authenticate with their own CRM credentials -- all MCP actions attributed to them personally
- Auto-runs `prisma db push` on startup to keep schema in sync for new instances

## OAuth endpoints
- `GET /.well-known/oauth-protected-resource` + `/.well-known/oauth-authorization-server` (discovery)
- `POST /oauth/register` (Dynamic Client Registration)
- `GET/POST /oauth/authorize` (dark-themed login + consent pages)
- `POST /oauth/token` (authorization code exchange + refresh token rotation)

## Test plan
- [ ] Verify `/.well-known/oauth-authorization-server` returns correct metadata
- [ ] Verify `POST /mcp` without auth returns 401 with `WWW-Authenticate` header
- [ ] Test OAuth flow: register client, authorize, exchange code, use token on `/mcp`
- [ ] Test from Claude: Settings > Connectors > Add custom connector > enter SpecterCRM URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)