### PR TITLE
Fix MCP session recovery and OAuth token expiry mismatch

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,6 +26,11 @@ AUTH_RATE_LIMIT_MAX=10
 # Password Reset
 PASSWORD_RESET_EXPIRES_IN=3600000
 
+# MCP Session Configuration
+# Session timeout in milliseconds (default: 1800000 = 30 minutes)
+# Should be less than JWT_EXPIRES_IN to avoid token expiry mid-session
+MCP_SESSION_TIMEOUT_MS=1800000
+
 # Logging
 LOG_LEVEL=info
 

--- a/backend/src/mcp/__tests__/transport.auth.test.ts
+++ b/backend/src/mcp/__tests__/transport.auth.test.ts
@@ -19,6 +19,7 @@ const mockVerifyAccessToken = vi.hoisted(() => vi.fn());
 vi.mock('../../utils/auth', () => ({
   verifyAccessToken: mockVerifyAccessToken,
   generateAccessToken: vi.fn(),
+  getAccessTokenTtlSeconds: vi.fn(() => 900),
   // JWTPayload is a TypeScript interface — no runtime value needed
 }));
 
@@ -421,8 +422,8 @@ describe('MCP Transport — Authentication Fixes', () => {
         .set('Authorization', 'Bearer fresh-token')
         .set('mcp-session-id', sessionId);
 
-      // Session still exists so we must NOT receive 400 "Session not found"
-      expect(freshRes.status).not.toBe(400);
+      // Session still exists so we must NOT receive 404 "Session not found"
+      expect(freshRes.status).not.toBe(404);
       // The mock transport returns 200 for authenticated requests to live sessions
       expect(freshRes.status).toBe(200);
     });

--- a/backend/src/mcp/__tests__/transport.test.ts
+++ b/backend/src/mcp/__tests__/transport.test.ts
@@ -8,6 +8,7 @@ const mockVerifyAccessToken = vi.hoisted(() => vi.fn());
 vi.mock('../../utils/auth', () => ({
   verifyAccessToken: mockVerifyAccessToken,
   generateAccessToken: vi.fn(),
+  getAccessTokenTtlSeconds: vi.fn(() => 900),
   JWTPayload: undefined, // Type export
 }));
 
@@ -119,7 +120,7 @@ describe('MCP Transport', () => {
       expect(res.status).toBe(200);
     });
 
-    it('should return 400 when session ID is provided but not found', async () => {
+    it('should return 404 when session ID is provided but not found', async () => {
       const mockAuth: JWTPayload = {
         userId: 'user-1',
         tenantId: 'tenant-1',
@@ -134,7 +135,7 @@ describe('MCP Transport', () => {
         .set('Authorization', 'Bearer valid-token')
         .set('mcp-session-id', 'nonexistent-session');
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(404);
       expect(res.body).toHaveProperty('error', 'Session not found');
     });
 

--- a/backend/src/mcp/transport.ts
+++ b/backend/src/mcp/transport.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto';
 import { TokenExpiredError } from 'jsonwebtoken';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { verifyAccessToken, JWTPayload } from '../utils/auth';
+import { verifyAccessToken, JWTPayload, getAccessTokenTtlSeconds } from '../utils/auth';
 import { logger } from '../utils/logger';
 import { createMcpServer } from './server';
 
@@ -16,13 +16,17 @@ interface McpSession {
 
 const sessions = new Map<string, McpSession>();
 
-// Session timeout: 30 minutes.
-// NOTE: This intentionally exceeds the default access token TTL (JWT_EXPIRES_IN = 15m)
-// so that sessions survive long enough for a client to refresh its token and continue
-// the same MCP conversation. In production, set JWT_EXPIRES_IN >= SESSION_TIMEOUT_MS
-// (e.g. JWT_EXPIRES_IN=35m) to prevent token expiry mid-session. See ADR-001.
-const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+// Session timeout (configurable via MCP_SESSION_TIMEOUT_MS, default 30 minutes).
+// Should be less than the JWT access token TTL so tokens don't expire mid-session.
+const SESSION_TIMEOUT_MS = parseInt(process.env.MCP_SESSION_TIMEOUT_MS || '1800000', 10);
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // Check every 5 minutes
+
+// Startup validation: log config and warn on mismatches
+const jwtTtlSeconds = getAccessTokenTtlSeconds();
+logger.info(`MCP config: session timeout=${SESSION_TIMEOUT_MS}ms (${(SESSION_TIMEOUT_MS / 60000).toFixed(0)}min), JWT TTL=${jwtTtlSeconds}s (${(jwtTtlSeconds / 60).toFixed(0)}min), cleanup interval=${(CLEANUP_INTERVAL_MS / 60000).toFixed(0)}min`);
+if (jwtTtlSeconds * 1000 < SESSION_TIMEOUT_MS) {
+  logger.warn(`JWT TTL (${jwtTtlSeconds}s) is less than MCP session timeout (${SESSION_TIMEOUT_MS / 1000}s). Tokens may expire mid-session, requiring client token refresh.`);
+}
 
 /**
  * Discriminated union result from JWT extraction / verification.
@@ -140,7 +144,8 @@ export function createMcpRouter(): Router {
         // Look up existing session
         session = sessions.get(sessionId)!;
         if (!session) {
-          res.status(400).json({ error: 'Session not found' });
+          logger.warn(`MCP session not found on POST: ${sessionId}. Active sessions: ${sessions.size}`);
+          res.status(404).json({ error: 'Session not found' });
           return;
         }
 
@@ -194,6 +199,7 @@ export function createMcpRouter(): Router {
       const auth = authResult.payload;
       const session = sessions.get(sessionId);
       if (!session) {
+        logger.warn(`MCP session not found on GET: ${sessionId}. Active sessions: ${sessions.size}`);
         res.status(404).json({ error: 'Session not found' });
         return;
       }
@@ -243,6 +249,7 @@ export function createMcpRouter(): Router {
       const auth = authResult.payload;
       const session = sessions.get(sessionId);
       if (!session) {
+        logger.warn(`MCP session not found on DELETE: ${sessionId}. Active sessions: ${sessions.size}`);
         res.status(404).json({ error: 'Session not found' });
         return;
       }

--- a/backend/src/oauth/service.ts
+++ b/backend/src/oauth/service.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import prisma from '../config/database';
-import { verifyPassword, generateAccessToken, hashToken, JWTPayload } from '../utils/auth';
+import { verifyPassword, generateAccessToken, hashToken, JWTPayload, getAccessTokenTtlSeconds } from '../utils/auth';
 import { AppError } from '../middleware/errorHandler';
 
 interface ClientRegistrationData {
@@ -242,7 +242,7 @@ export class OAuthService {
     return {
       access_token: accessToken,
       token_type: 'bearer',
-      expires_in: 900, // 15 minutes
+      expires_in: getAccessTokenTtlSeconds(),
       refresh_token: refreshToken,
       scope: authCode.scope || 'crm:read crm:write',
     };
@@ -314,7 +314,7 @@ export class OAuthService {
     return {
       access_token: accessToken,
       token_type: 'bearer',
-      expires_in: 900,
+      expires_in: getAccessTokenTtlSeconds(),
       refresh_token: newRefreshToken,
       scope: storedToken.scope || 'crm:read crm:write',
     };

--- a/backend/src/utils/__tests__/auth.test.ts
+++ b/backend/src/utils/__tests__/auth.test.ts
@@ -8,6 +8,8 @@ import {
   verifyRefreshToken,
   hashToken,
   generatePasswordResetToken,
+  parseDurationToSeconds,
+  getAccessTokenTtlSeconds,
   type JWTPayload,
 } from '../auth';
 import jwt from 'jsonwebtoken';
@@ -203,6 +205,53 @@ describe('auth utils', () => {
 
       // Hex only contains 0-9 and a-f
       expect(token).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+
+  describe('parseDurationToSeconds', () => {
+    it('should parse minutes', () => {
+      expect(parseDurationToSeconds('15m')).toBe(900);
+    });
+
+    it('should parse hours', () => {
+      expect(parseDurationToSeconds('8h')).toBe(28800);
+    });
+
+    it('should parse days', () => {
+      expect(parseDurationToSeconds('1d')).toBe(86400);
+    });
+
+    it('should parse seconds', () => {
+      expect(parseDurationToSeconds('30s')).toBe(30);
+    });
+
+    it('should parse bare numbers as seconds', () => {
+      expect(parseDurationToSeconds('3600')).toBe(3600);
+    });
+
+    it('should handle whitespace', () => {
+      expect(parseDurationToSeconds('  15m  ')).toBe(900);
+    });
+
+    it('should return 900 for unparseable input', () => {
+      expect(parseDurationToSeconds('bogus')).toBe(900);
+      expect(parseDurationToSeconds('')).toBe(900);
+    });
+  });
+
+  describe('getAccessTokenTtlSeconds', () => {
+    it('should read from JWT_EXPIRES_IN env var', () => {
+      const original = process.env.JWT_EXPIRES_IN;
+      process.env.JWT_EXPIRES_IN = '2h';
+      expect(getAccessTokenTtlSeconds()).toBe(7200);
+      process.env.JWT_EXPIRES_IN = original;
+    });
+
+    it('should default to 900 (15m) when env var is not set', () => {
+      const original = process.env.JWT_EXPIRES_IN;
+      delete process.env.JWT_EXPIRES_IN;
+      expect(getAccessTokenTtlSeconds()).toBe(900);
+      process.env.JWT_EXPIRES_IN = original;
     });
   });
 });

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -47,3 +47,34 @@ export function hashToken(token: string): string {
 export function generatePasswordResetToken(): string {
   return crypto.randomBytes(32).toString('hex');
 }
+
+/**
+ * Parse a duration string (e.g., "8h", "15m", "1d", "3600") into seconds.
+ * Supports suffixes: s (seconds), m (minutes), h (hours), d (days).
+ * Bare numbers are treated as seconds (jsonwebtoken convention).
+ * Falls back to 900 (15 minutes) if the input is unparseable.
+ */
+export function parseDurationToSeconds(duration: string): number {
+  const match = duration.trim().match(/^(\d+)\s*([smhd]?)$/i);
+  if (!match) return 900;
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2].toLowerCase();
+
+  switch (unit) {
+    case 's': return value;
+    case 'm': return value * 60;
+    case 'h': return value * 3600;
+    case 'd': return value * 86400;
+    case '':  return value;
+    default:  return 900;
+  }
+}
+
+/**
+ * Return the configured JWT access token TTL in seconds.
+ * Reads JWT_EXPIRES_IN from environment, defaulting to '15m'.
+ */
+export function getAccessTokenTtlSeconds(): number {
+  return parseDurationToSeconds(process.env.JWT_EXPIRES_IN || '15m');
+}


### PR DESCRIPTION
## Summary
- **Fix POST 400→404 for unknown session IDs** — MCP spec requires 404 to tell clients to create a new session. This was the root cause of needing manual disconnect/reconnect after server restart.
- **Fix hardcoded `expires_in: 900` in OAuth token responses** — now dynamically computed from `JWT_EXPIRES_IN` env var so MCP clients (Claude) know the real token lifetime and refresh correctly.
- **Make session timeout configurable** via `MCP_SESSION_TIMEOUT_MS` env var, with startup validation logging for JWT TTL mismatches.
- **Add warning logs** on all session-not-found paths to help ops debug post-restart issues.

## Test plan
- [x] All 633 existing tests pass
- [x] New unit tests for `parseDurationToSeconds` and `getAccessTokenTtlSeconds`
- [x] Updated transport tests: POST session-not-found now expects 404
- [ ] Manual: restart server → MCP client auto-creates new session (no disconnect needed)
- [ ] Manual: verify startup logs show MCP config and warn if JWT TTL < session timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)